### PR TITLE
fix: correct typo in MQTT publish function call

### DIFF
--- a/en_US/connect_to_deployments/esp8266.md
+++ b/en_US/connect_to_deployments/esp8266.md
@@ -94,7 +94,7 @@ void connectToMQTTBroker() {
             Serial.println("Connected to MQTT broker");
             mqtt_client.subscribe(mqtt_topic);
             // Publish message upon successful connection
-            mqtt_client.publish(topic, "Hi EMQX I'm ESP8266 ^^");
+            mqtt_client.publish(mqtt_topic, "Hi EMQX I'm ESP8266 ^^");
         } else {
             Serial.print("Failed to connect to MQTT broker, rc=");
             Serial.print(mqtt_client.state());
@@ -110,7 +110,7 @@ void connectToMQTTBroker() {
 ```c
 mqtt_client.subscribe(mqtt_topic);
 // Publish message upon successful connection
-mqtt_client.publish(topic, "Hi EMQX I'm ESP8266 ^^");
+mqtt_client.publish(mqtt_topic, "Hi EMQX I'm ESP8266 ^^");
 ```
 
 6. Print the topic name to the serial port and then print every byte of received messages.
@@ -180,7 +180,7 @@ void connectToMQTTBroker() {
             Serial.println("Connected to MQTT broker");
             mqtt_client.subscribe(mqtt_topic);
             // Publish message upon successful connection
-            mqtt_client.publish(topic, "Hi EMQX I'm ESP8266 ^^");
+            mqtt_client.publish(mqtt_topic, "Hi EMQX I'm ESP8266 ^^");
         } else {
             Serial.print("Failed to connect to MQTT broker, rc=");
             Serial.print(mqtt_client.state());
@@ -343,7 +343,7 @@ void connectToMQTT() {
             Serial.println("Connected to MQTT broker");
             mqtt_client.subscribe(mqtt_topic);
             // Publish message upon successful connection
-            mqtt_client.publish(topic, "Hi EMQX I'm ESP8266 ^^");
+            mqtt_client.publish(mqtt_topic, "Hi EMQX I'm ESP8266 ^^");
         } else {
             char err_buf[128];
             espClient.getLastSSLError(err_buf, sizeof(err_buf));
@@ -362,7 +362,7 @@ void connectToMQTT() {
 ```c
 mqtt_client.subscribe(mqtt_topic);
 // Publish message upon successful connection
-mqtt_client.publish(topic, "Hi EMQX I'm ESP8266 ^^");
+mqtt_client.publish(mqtt_topic, "Hi EMQX I'm ESP8266 ^^");
 ```
 
 7. Print the topic name to the serial port and then print every byte of received messages.
@@ -519,7 +519,7 @@ void connectToMQTT() {
             Serial.println("Connected to MQTT broker");
             mqtt_client.subscribe(mqtt_topic);
             // Publish message upon successful connection
-            mqtt_client.publish(topic, "Hi EMQX I'm ESP8266 ^^");
+            mqtt_client.publish(mqtt_topic, "Hi EMQX I'm ESP8266 ^^");
         } else {
             char err_buf[128];
             espClient.getLastSSLError(err_buf, sizeof(err_buf));


### PR DESCRIPTION
The project documentation contained a typo in the line where the `mqtt_client.publish()` function is called. The variable `mqtt_topic` was incorrectly written as `topic`. This fix adjusts the `mqtt_client.publish()` call to use the correct variable, ensuring the accuracy of the documentation and the proper functionality of the code.